### PR TITLE
Set cplice correctly in sm sept21 pr for coupled and uncoupled runs

### DIFF
--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -619,6 +619,7 @@ export H2O_PHYS=.false.
 export CPL=.false.
 export CPLCHM=.false.
 export CPLFLX=.false.
+export CPLICE=.false.
 export CPLWAV=.false.
 export CPLWAV2ATM=.false.
 export DAYS=1
@@ -863,6 +864,7 @@ export KTHERM=2
 export TFREEZE_OPTION=mushy
 
 export CPLFLX=.true.
+export CPLICE=.true.
 export CPL=.true.
 export MIN_SEAICE=1.0e-11
 

--- a/tests/parm/cpld_control.nml.IN
+++ b/tests/parm/cpld_control.nml.IN
@@ -178,6 +178,7 @@ deflate_level=1
   cplwav       = @[CPLWAV]
   cplwav2atm   = @[CPLWAV2ATM]
   cplflx       = @[CPLFLX]
+  cplice       = @[CPLICE]
   min_seaice   = @[MIN_SEAICE]
   use_cice_alb = @[USE_CICE_ALB]
   frac_grid    = @[FRAC_GRID]


### PR DESCRIPTION
Please take a good look. This should work for uncoupled and coupled (S2S) configurations. I think that also the HAFS test will still be correct, because they have hardcoded `cplice = .false.` in `tests/parm/input_hafs_regional.nml.IN`.